### PR TITLE
password: fix built in validations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
 import zxcvbn from 'zxcvbn'
 import commonPasswords from './common-passwords'
 
-const calculatePasswordScore = password => zxcvbn(password).score
+const calculatePasswordScore = password => password && zxcvbn(password).score
 
 const hasMinimumLength = (password, length = 8) =>
-  (password.length >= length)
+  password && (password.length >= length)
 
 const hasMaximumLength = (password, length = 64) =>
-  (password.length <= length)
+  password && (password.length <= length)
 
 const isCommonPassword = password => commonPasswords.includes(password)
 

--- a/test/unit/is-valid.js
+++ b/test/unit/is-valid.js
@@ -10,3 +10,8 @@ test('Validate a invalid password', (t) => {
   const { isValid } = validate('you wi!! never c@tch meeee333')
   t.is(isValid, true)
 })
+
+test('Validate a invalid undefined password', (t) => {
+  const { isValid } = validate(undefined)
+  t.is(isValid, false)
+})


### PR DESCRIPTION
Este PR corrigi o problema de validar o `length` da senha sem verificar se é um valor truthy, evitando assim que acabando disparando um erro.

Resolve #17 
