### PR TITLE
Refatora o score para ser sempre um número

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 import zxcvbn from 'zxcvbn'
 import commonPasswords from './common-passwords'
 
-const calculatePasswordScore = password => password && zxcvbn(password).score
+const calculatePasswordScore = password => typeof password === 'string'
+  ? zxcvbn(password).score
+  : 0
 
 const hasMinimumLength = (password, length = 8) =>
   password && (password.length >= length)

--- a/test/unit/calculate-password-score.js
+++ b/test/unit/calculate-password-score.js
@@ -25,3 +25,8 @@ test('Very unguessable password zxcvbn calculation', (t) => {
   const { score: scoreResult } = validate('He!! 0f A p@A55w0rd')
   t.is(scoreResult, 4)
 })
+
+test('Should return zero if provided with an empty password', (t) => {
+  const { score } = validate('')
+  t.is(score, 0)
+})

--- a/test/unit/is-valid.js
+++ b/test/unit/is-valid.js
@@ -12,6 +12,19 @@ test('Validate a invalid password', (t) => {
 })
 
 test('Validate a invalid undefined password', (t) => {
-  const { isValid } = validate(undefined)
+  const { isValid, score } = validate(undefined)
   t.is(isValid, false)
+  t.is(score, 0)
+})
+
+test('Validate a invalid object password', (t) => {
+  const { isValid, score } = validate({})
+  t.is(isValid, false)
+  t.is(score, 0)
+})
+
+test('Validate a invalid number password', (t) => {
+  const { isValid, score } = validate(123456789)
+  t.is(isValid, false)
+  t.is(score, 0)
 })


### PR DESCRIPTION
Hoje se informamos uma string vazia como senha, o score não é validado e nele é retornado uma string vazia `''`, o que gera uma inconsistência com o tipo do dado dessa prop, que hora pode ser `string` e hora pode ser `number`. 

Neste PR adiciono uma validação que faz com que o score seja zero para qualquer senha que não for uma string, e faz o calculo ocorrer normalmente caso o contrário. Retornando zero para senhas vazias e mantendo sempre o mesmo tipo de dado não importando a senha informada.